### PR TITLE
Update the goreleaser config file and copyright

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
   hooks:
     - make tfgen
 builds:
-  - binary: pulumi-resource-xyz
+  - binary: pulumi-resource-xenorchestra
     dir: provider
     env:
       - CGO_ENABLED=0

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -6,6 +6,6 @@ This project is a larger work that combines with software written
 by third parties, licensed under their own terms.
 
 Notably, this larger work combines with the Terraform Xenorchestra
-Provider, which is licensed under the Mozilla Public License 2.0 (see
-<https://www.mozilla.org/en-US/MPL/2.0/> or the project itself at
-<https://github.com/terraform-providers/terraform-provider-aws>).
+Provider, which is licensed under the MIT License (see
+<https://opensource.org/license/mit> or the project itself at
+<https://github.com/vatesfr/terraform-provider-xenorchestra>).

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -5,7 +5,7 @@ LICENSE or <http://www.apache.org/licenses/LICENSE-2.0>).
 This project is a larger work that combines with software written
 by third parties, licensed under their own terms.
 
-Notably, this larger work combines with the Terraform XYZ Provider,
-which is licensed under the Mozilla Public License 2.0 (see
+Notably, this larger work combines with the Terraform Xenorchestra
+Provider, which is licensed under the Mozilla Public License 2.0 (see
 <https://www.mozilla.org/en-US/MPL/2.0/> or the project itself at
 <https://github.com/terraform-providers/terraform-provider-aws>).


### PR DESCRIPTION
The goreleaser config file uses the template binary name "XYZ".

I also fixed the copyright file which had the same problem and did not match the Xenorchestra terraform provider license.