### PR TITLE
fix(build): patch python and nodejs SDKs to set correct version

### DIFF
--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -63,8 +63,7 @@ jobs:
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
       - name: Restore makefile progress
-        # touch generate to avoir sdk regeneration, see bug https://github.com/pulumi/pulumi-tf-provider-boilerplate/issues/224
-        run: make --touch provider schema generate
+        run: make --touch provider schema
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
@@ -77,7 +76,7 @@ jobs:
             sdk/dotnet/*.csproj
             sdk/go/**/pulumiUtilities.go
             sdk/nodejs/package.json
-            sdk/python/pyproject.toml
+            sdk/python/setup.py
       - name: Commit ${{ matrix.language }} SDK changes for Renovate
         # If the worktree is dirty and this is a Renovate PR to bump
         # dependencies, commit the updated SDK and push it back to the PR. The

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ build_nodejs: .make/build_nodejs
 .make/generate_nodejs: .make/install_plugins bin/$(CODEGEN)
 	$(GEN_ENVS) $(WORKING_DIR)/bin/$(CODEGEN) nodejs --out sdk/nodejs/
 	printf "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/nodejs/go.mod
+	sed -i 's/$${VERSION}/$(PROVIDER_VERSION)/g' sdk/nodejs/package.json
 	@touch $@
 .make/build_nodejs: .make/generate_nodejs
 	cd sdk/nodejs/ && \
@@ -159,6 +160,7 @@ build_python: .make/build_python
 	$(GEN_ENVS) $(WORKING_DIR)/bin/$(CODEGEN) python --out sdk/python/
 	printf "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/python/go.mod
 	cp README.md sdk/python/
+	sed -i -r 's/(VERSION = ")[0-9]+.[0-9]+.[0-9]+(")/\1$(PROVIDER_VERSION)\2/g' sdk/python/setup.py
 	@touch $@
 .make/build_python: .make/generate_python
 	cd sdk/python/ && \


### PR DESCRIPTION
With previous workaround SDKs were not generated by the CI and version numbers mismatch in the "Publish sdk" job ([see](https://github.com/vatesfr/pulumi-xenorchestra/actions/runs/13283511486/job/37087192965))

This fix will patch the SDKs to set the correct version and ignore the change in the "git-status-check" action.
